### PR TITLE
Add aesthetic package management workflow

### DIFF
--- a/interface/billing/saude_estetica/packages.php
+++ b/interface/billing/saude_estetica/packages.php
@@ -1,0 +1,353 @@
+<?php
+/**
+ * Administrative interface for building Saúde & Estética treatment packages.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    OpenAI Assistant
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once(__DIR__ . '/../../globals.php');
+require_once($GLOBALS['srcdir'] . '/options.inc.php');
+
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Core\Header;
+use OpenEMR\Services\Aesthetic\PackageService;
+
+if (!AclMain::aclCheckCore('admin', 'super')) {
+    die(xlt('Not authorized.'));
+}
+
+$service = new PackageService();
+$service->ensureSchema();
+
+$messages = [];
+$errors = [];
+$editPackageId = (int)($_GET['package_id'] ?? 0);
+$packageToEdit = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!CsrfUtils::verifyCsrfToken($_POST['csrf_token_form'] ?? '')) {
+        CsrfUtils::csrfNotVerified();
+    }
+
+    $action = $_POST['action'] ?? '';
+    if ($action === 'save_package') {
+        $payload = [
+            'package_id' => $_POST['package_id'] ?? null,
+            'package_code' => $_POST['package_code'] ?? null,
+            'name' => $_POST['name'] ?? null,
+            'description' => $_POST['description'] ?? null,
+            'base_price' => $_POST['base_price'] ?? null,
+            'promo_price' => $_POST['promo_price'] ?? null,
+            'promo_start_date' => $_POST['promo_start_date'] ?? null,
+            'promo_end_date' => $_POST['promo_end_date'] ?? null,
+            'periodicity_unit' => $_POST['periodicity_unit'] ?? null,
+            'periodicity_count' => $_POST['periodicity_count'] ?? null,
+            'session_count' => $_POST['session_count'] ?? null,
+            'installment_counts' => $_POST['installment_counts'] ?? [],
+            'installment_amounts' => $_POST['installment_amounts'] ?? [],
+            'installment_descriptions' => $_POST['installment_descriptions'] ?? [],
+            'is_active' => !empty($_POST['is_active']),
+        ];
+        $result = $service->savePackage($payload);
+        if ($result->hasErrors() || $result->hasValidationMessages()) {
+            $errors = array_merge($errors, $result->getValidationMessages());
+            $errors = array_merge($errors, $result->getInternalErrors());
+            $packageToEdit = $payload;
+        } else {
+            $messages[] = xlt('Package saved successfully.');
+            $data = $result->getData();
+            if (!empty($data[0]['package_id'])) {
+                $editPackageId = (int)$data[0]['package_id'];
+            }
+        }
+    } elseif ($action === 'delete_package') {
+        $packageId = (int)($_POST['package_id'] ?? 0);
+        if ($packageId > 0) {
+            $service->deletePackage($packageId);
+            $messages[] = xlt('Package removed.');
+            if ($editPackageId === $packageId) {
+                $editPackageId = 0;
+            }
+        }
+    }
+}
+
+$packages = $service->listPackages(false);
+if ($packageToEdit === null && $editPackageId > 0) {
+    $packageToEdit = $service->getPackage($editPackageId);
+}
+
+$periodicityUnits = [
+    'day' => xlt('Days'),
+    'week' => xlt('Weeks'),
+    'month' => xlt('Months'),
+    'year' => xlt('Years'),
+];
+
+Header::setupHeader(['datetime-picker', 'jquery-ui']);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title><?php echo xlt('Saúde & Estética Packages'); ?></title>
+    <style>
+        .package-summary-table th,
+        .package-summary-table td {
+            vertical-align: top;
+        }
+        .installment-table th,
+        .installment-table td {
+            vertical-align: middle;
+        }
+        .installment-table input[type="number"] {
+            width: 100px;
+        }
+        .installment-table input[type="text"] {
+            width: 220px;
+        }
+    </style>
+</head>
+<body class="container-fluid">
+    <div class="page-header">
+        <h2 class="title"><?php echo xlt('Saúde & Estética Packages'); ?></h2>
+    </div>
+
+    <?php if (!empty($messages)) : ?>
+        <div class="alert alert-success">
+            <ul class="mb-0">
+                <?php foreach ($messages as $message) : ?>
+                    <li><?php echo text($message); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($errors)) : ?>
+        <div class="alert alert-danger">
+            <ul class="mb-0">
+                <?php foreach ($errors as $field => $error) : ?>
+                    <li><?php echo text(is_numeric($field) ? $error : ($field . ': ' . $error)); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <div class="row">
+        <div class="col-lg-6">
+            <div class="card mb-3">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span><?php echo xlt('Configured Packages'); ?></span>
+                    <a class="btn btn-sm btn-primary" href="<?php echo attr($_SERVER['PHP_SELF']); ?>">
+                        <i class="fa fa-plus"></i> <?php echo xlt('New Package'); ?>
+                    </a>
+                </div>
+                <div class="card-body table-responsive p-0">
+                    <table class="table table-striped table-hover package-summary-table mb-0">
+                        <thead>
+                            <tr>
+                                <th><?php echo xlt('Name'); ?></th>
+                                <th><?php echo xlt('Pricing'); ?></th>
+                                <th><?php echo xlt('Periodicity'); ?></th>
+                                <th><?php echo xlt('Sessions'); ?></th>
+                                <th><?php echo xlt('Status'); ?></th>
+                                <th class="text-end"><?php echo xlt('Actions'); ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php if (empty($packages)) : ?>
+                                <tr>
+                                    <td colspan="6" class="text-center text-muted"><?php echo xlt('No packages configured yet.'); ?></td>
+                                </tr>
+                            <?php endif; ?>
+                            <?php foreach ($packages as $package) : ?>
+                                <tr>
+                                    <td>
+                                        <strong><?php echo text($package['name']); ?></strong><br />
+                                        <small class="text-muted"><?php echo text($package['package_code']); ?></small>
+                                    </td>
+                                    <td>
+                                        <?php echo text(oeFormatMoney($package['base_price'])); ?><br />
+                                        <?php if (!empty($package['promo_price'])) : ?>
+                                            <span class="badge bg-success">
+                                                <?php echo xlt('Promo:'); ?> <?php echo text(oeFormatMoney($package['promo_price'])); ?>
+                                            </span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <?php echo text($package['periodicity_count']); ?>
+                                        <?php echo text($periodicityUnits[$package['periodicity_unit']] ?? $package['periodicity_unit']); ?>
+                                    </td>
+                                    <td><?php echo text($package['session_count'] ?? '-'); ?></td>
+                                    <td>
+                                        <?php if (!empty($package['is_active'])) : ?>
+                                            <span class="badge bg-primary"><?php echo xlt('Active'); ?></span>
+                                        <?php else : ?>
+                                            <span class="badge bg-secondary"><?php echo xlt('Inactive'); ?></span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td class="text-end">
+                                        <a class="btn btn-sm btn-outline-secondary" href="<?php echo attr($_SERVER['PHP_SELF'] . '?package_id=' . urlencode($package['package_id'])); ?>">
+                                            <i class="fa fa-edit"></i>
+                                        </a>
+                                        <form class="d-inline" method="post" onsubmit="return confirm(<?php echo xlj('Remove this package?'); ?>);">
+                                            <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+                                            <input type="hidden" name="action" value="delete_package" />
+                                            <input type="hidden" name="package_id" value="<?php echo attr($package['package_id']); ?>" />
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">
+                                                <i class="fa fa-trash"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card">
+                <div class="card-header">
+                    <?php echo $editPackageId > 0 ? xlt('Edit Package') : xlt('New Package'); ?>
+                </div>
+                <div class="card-body">
+                    <form method="post" id="package-form" autocomplete="off">
+                        <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+                        <input type="hidden" name="action" value="save_package" />
+                        <input type="hidden" name="package_id" value="<?php echo attr($packageToEdit['package_id'] ?? ''); ?>" />
+                        <div class="mb-3">
+                            <label class="form-label" for="package_code"><?php echo xlt('Package Code'); ?></label>
+                            <input type="text" class="form-control" id="package_code" name="package_code" value="<?php echo attr($packageToEdit['package_code'] ?? ''); ?>" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="name"><?php echo xlt('Name'); ?> <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="name" name="name" required value="<?php echo attr($packageToEdit['name'] ?? ''); ?>" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="description"><?php echo xlt('Description'); ?></label>
+                            <textarea class="form-control" id="description" name="description" rows="3"><?php echo text($packageToEdit['description'] ?? ''); ?></textarea>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-4 mb-3">
+                                <label class="form-label" for="base_price"><?php echo xlt('Base Price'); ?> <span class="text-danger">*</span></label>
+                                <input type="number" step="0.01" class="form-control" id="base_price" name="base_price" required value="<?php echo attr($packageToEdit['base_price'] ?? ''); ?>" />
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label class="form-label" for="promo_price"><?php echo xlt('Promo Price'); ?></label>
+                                <input type="number" step="0.01" class="form-control" id="promo_price" name="promo_price" value="<?php echo attr($packageToEdit['promo_price'] ?? ''); ?>" />
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label class="form-label" for="session_count"><?php echo xlt('Sessions Included'); ?></label>
+                                <input type="number" min="0" class="form-control" id="session_count" name="session_count" value="<?php echo attr($packageToEdit['session_count'] ?? ''); ?>" />
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="promo_start_date"><?php echo xlt('Promo Start'); ?></label>
+                                <input type="text" class="form-control datepicker" id="promo_start_date" name="promo_start_date" value="<?php echo attr($packageToEdit['promo_start_date'] ?? ''); ?>" />
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="promo_end_date"><?php echo xlt('Promo End'); ?></label>
+                                <input type="text" class="form-control datepicker" id="promo_end_date" name="promo_end_date" value="<?php echo attr($packageToEdit['promo_end_date'] ?? ''); ?>" />
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="periodicity_count"><?php echo xlt('Repeat Every'); ?></label>
+                                <input type="number" min="1" class="form-control" id="periodicity_count" name="periodicity_count" value="<?php echo attr($packageToEdit['periodicity_count'] ?? 1); ?>" />
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="periodicity_unit"><?php echo xlt('Unit'); ?></label>
+                                <select class="form-select" id="periodicity_unit" name="periodicity_unit">
+                                    <?php foreach ($periodicityUnits as $unitKey => $label) : ?>
+                                        <option value="<?php echo attr($unitKey); ?>" <?php echo (!empty($packageToEdit['periodicity_unit']) && $packageToEdit['periodicity_unit'] === $unitKey) ? 'selected' : ''; ?>>
+                                            <?php echo text($label); ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" id="is_active" name="is_active" value="1" <?php echo (!empty($packageToEdit['is_active']) || $packageToEdit === null) ? 'checked' : ''; ?> />
+                            <label class="form-check-label" for="is_active"><?php echo xlt('Package available for new subscriptions'); ?></label>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label"><?php echo xlt('Installment Options'); ?></label>
+                            <table class="table table-sm table-bordered installment-table" id="installment-table">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 15%;"><?php echo xlt('Installments'); ?></th>
+                                        <th style="width: 20%;"><?php echo xlt('Amount'); ?></th>
+                                        <th><?php echo xlt('Description'); ?></th>
+                                        <th style="width: 5%;"></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php
+                                    $existingPlans = [];
+                                    if (!empty($packageToEdit['installment_options'])) {
+                                        $existingPlans = json_decode($packageToEdit['installment_options'], true) ?: [];
+                                    }
+                                    if (empty($existingPlans)) {
+                                        $existingPlans = [[]];
+                                    }
+                                    foreach ($existingPlans as $plan) :
+                                    ?>
+                                        <tr>
+                                            <td><input type="number" min="1" class="form-control" name="installment_counts[]" value="<?php echo attr($plan['installments'] ?? ''); ?>" /></td>
+                                            <td><input type="number" min="0" step="0.01" class="form-control" name="installment_amounts[]" value="<?php echo attr($plan['amount'] ?? ''); ?>" /></td>
+                                            <td><input type="text" class="form-control" name="installment_descriptions[]" value="<?php echo attr($plan['description'] ?? ''); ?>" /></td>
+                                            <td class="text-center"><button type="button" class="btn btn-link text-danger remove-installment" title="<?php echo xla('Remove'); ?>"><i class="fa fa-times"></i></button></td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" id="add-installment">
+                                <i class="fa fa-plus"></i> <?php echo xlt('Add option'); ?>
+                            </button>
+                        </div>
+
+                        <div class="text-end">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fa fa-save"></i> <?php echo xlt('Save Package'); ?>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        $(function () {
+            $('.datepicker').datetimepicker({
+                timepicker: false,
+                format: 'Y-m-d'
+            });
+
+            $('#add-installment').on('click', function () {
+                const row = `<tr>
+                    <td><input type="number" min="1" class="form-control" name="installment_counts[]" /></td>
+                    <td><input type="number" min="0" step="0.01" class="form-control" name="installment_amounts[]" /></td>
+                    <td><input type="text" class="form-control" name="installment_descriptions[]" /></td>
+                    <td class="text-center"><button type="button" class="btn btn-link text-danger remove-installment" title="<?php echo xla('Remove'); ?>"><i class="fa fa-times"></i></button></td>
+                </tr>`;
+                $('#installment-table tbody').append(row);
+            });
+
+            $('#installment-table').on('click', '.remove-installment', function () {
+                if ($('#installment-table tbody tr').length <= 1) {
+                    $(this).closest('tr').find('input').val('');
+                    return;
+                }
+                $(this).closest('tr').remove();
+            });
+        });
+    </script>
+</body>
+</html>

--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -936,6 +936,31 @@
         ]
       },
       {
+        "label": "Saúde & Estética",
+        "icon": "fa-caret-right",
+        "children": [
+          {
+            "label": "Pacotes",
+            "menu_id": "adm0",
+            "target": "adm",
+            "url": "/interface/billing/saude_estetica/packages.php",
+            "children": [],
+            "requirement": 0,
+            "acl_req": [
+              "admin",
+              "super"
+            ]
+          }
+        ],
+        "requirement": 0,
+        "acl_req": [
+          [
+            "admin",
+            "super"
+          ]
+        ]
+      },
+      {
         "label": "Coding",
         "icon": "fa-caret-right",
         "children": [

--- a/interface/patient_file/saude_estetica/package_sessions.php
+++ b/interface/patient_file/saude_estetica/package_sessions.php
@@ -1,0 +1,552 @@
+<?php
+/**
+ * Patient facing package tracking screen for Saúde & Estética flows.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    OpenAI Assistant
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once(__DIR__ . '/../../globals.php');
+require_once($GLOBALS['srcdir'] . '/options.inc.php');
+require_once($GLOBALS['srcdir'] . '/forms.inc.php');
+
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Core\Header;
+use OpenEMR\Services\Aesthetic\PackageService;
+use OpenEMR\Validators\ProcessingResult;
+
+$pid = (int)($_GET['pid'] ?? 0);
+if ($pid <= 0) {
+    die(xlt('Patient context is required.'));
+}
+
+if (!AclMain::aclCheckCore('patients', 'med')) {
+    die(xlt('Not authorized.'));
+}
+
+$service = new PackageService();
+$service->ensureSchema();
+
+$alerts = [];
+$errors = [];
+
+$packages = $service->listPackages(true);
+$packageOptions = [];
+foreach ($packages as $package) {
+    $packageOptions[$package['package_id']] = $package;
+}
+
+$providerRows = QueryUtils::fetchRecords(
+    'SELECT id, fname, lname FROM users WHERE active = 1 AND authorized = 1 ORDER BY lname, fname',
+    [],
+    true
+);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!CsrfUtils::verifyCsrfToken($_POST['csrf_token_form'] ?? '')) {
+        CsrfUtils::csrfNotVerified();
+    }
+
+    $action = $_POST['action'] ?? '';
+    switch ($action) {
+        case 'create_subscription':
+            $payload = [
+                'patient_id' => $pid,
+                'package_id' => $_POST['package_id'] ?? null,
+                'start_date' => $_POST['start_date'] ?? null,
+                'end_date' => $_POST['end_date'] ?? null,
+                'status' => $_POST['status'] ?? 'active',
+                'total_sessions' => $_POST['total_sessions'] ?? null,
+                'installment_plan' => $_POST['installment_plan'] ?? null,
+                'total_amount' => $_POST['total_amount'] ?? null,
+                'promo_price' => $_POST['promo_price'] ?? null,
+                'recurring_amount' => $_POST['recurring_amount'] ?? null,
+                'next_session_date' => $_POST['next_session_date'] ?? null,
+                'next_billing_date' => $_POST['next_billing_date'] ?? null,
+                'billing_cycle_unit' => $_POST['billing_cycle_unit'] ?? null,
+                'billing_cycle_count' => $_POST['billing_cycle_count'] ?? null,
+                'auto_bill' => !empty($_POST['auto_bill']),
+                'pos_customer_reference' => $_POST['pos_customer_reference'] ?? null,
+                'pos_agreement_reference' => $_POST['pos_agreement_reference'] ?? null,
+                'gateway_identifier' => $_POST['gateway_identifier'] ?? null,
+                'receipt_email' => $_POST['receipt_email'] ?? null,
+            ];
+            $result = $service->createSubscription($payload);
+            if ($result->hasErrors() || $result->hasValidationMessages()) {
+                $errors = array_merge($errors, format_processing_errors($result));
+            } else {
+                $alerts[] = xlt('Subscription created successfully.');
+            }
+            break;
+        case 'log_session':
+            $payload = [
+                'subscription_id' => $_POST['subscription_id'] ?? null,
+                'log_type' => 'session',
+                'session_date' => $_POST['session_date'] ?? null,
+                'status' => $_POST['session_status'] ?? null,
+                'provider_id' => $_POST['provider_id'] ?? null,
+                'appointment_id' => $_POST['appointment_id'] ?? null,
+                'duration_minutes' => $_POST['duration_minutes'] ?? null,
+                'notes' => $_POST['notes'] ?? null,
+            ];
+            $result = $service->logSubscriptionEvent($payload);
+            if ($result->hasErrors() || $result->hasValidationMessages()) {
+                $errors = array_merge($errors, format_processing_errors($result));
+            } else {
+                $alerts[] = xlt('Session event recorded.');
+            }
+            break;
+        case 'record_payment':
+            $subscriptionId = (int)($_POST['payment_subscription_id'] ?? 0);
+            $amount = $_POST['payment_amount'] ?? null;
+            if ($subscriptionId <= 0 || $amount === null || $amount === '') {
+                $errors[] = xlt('A subscription and payment amount are required.');
+                break;
+            }
+            $metadata = [
+                'payment_reference' => $_POST['payment_reference'] ?? null,
+                'receipt_reference' => $_POST['receipt_reference'] ?? null,
+                'notes' => $_POST['payment_notes'] ?? null,
+                'next_billing_date' => $_POST['payment_next_billing'] ?? null,
+            ];
+            $service->registerRecurringPayment($subscriptionId, (float)$amount, $_POST['payment_date'] ?? null, $metadata);
+            $alerts[] = xlt('Recurring payment registered.');
+            break;
+    }
+}
+
+$subscriptions = $service->getSubscriptionsForPatient($pid);
+$subscriptionOptions = [];
+foreach ($subscriptions as $subscription) {
+    $subscriptionOptions[$subscription['subscription_id']] = $subscription;
+}
+
+Header::setupHeader(['datetime-picker', 'jquery-ui']);
+
+function format_processing_errors(ProcessingResult $result): array
+{
+    $messages = [];
+    foreach ((array)$result->getValidationMessages() as $field => $text) {
+        if (is_array($text)) {
+            foreach ($text as $item) {
+                $messages[] = (is_numeric($field) ? '' : $field . ': ') . $item;
+            }
+        } else {
+            $messages[] = (is_numeric($field) ? '' : $field . ': ') . $text;
+        }
+    }
+    foreach ($result->getInternalErrors() as $error) {
+        $messages[] = (string)$error;
+    }
+    return $messages;
+}
+
+$packageInstallments = [];
+foreach ($packages as $package) {
+    $packageInstallments[$package['package_id']] = [];
+    if (!empty($package['installment_options'])) {
+        $decoded = json_decode($package['installment_options'], true) ?: [];
+        foreach ($decoded as $plan) {
+            $packageInstallments[$package['package_id']][] = $plan;
+        }
+    }
+}
+
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title><?php echo xlt('Treatment Packages'); ?></title>
+    <style>
+        .subscription-card + .subscription-card {
+            margin-top: 1rem;
+        }
+        .session-log-table td,
+        .session-log-table th {
+            vertical-align: middle;
+        }
+    </style>
+</head>
+<body class="container-fluid">
+    <div class="page-header">
+        <h2 class="title"><?php echo xlt('Treatment Packages for Patient'); ?></h2>
+    </div>
+
+    <?php if (!empty($alerts)) : ?>
+        <div class="alert alert-success">
+            <ul class="mb-0">
+                <?php foreach ($alerts as $message) : ?>
+                    <li><?php echo text($message); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($errors)) : ?>
+        <div class="alert alert-danger">
+            <ul class="mb-0">
+                <?php foreach ($errors as $error) : ?>
+                    <li><?php echo text($error); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <div class="row">
+        <div class="col-lg-4">
+            <div class="card mb-3">
+                <div class="card-header"><?php echo xlt('Create Subscription'); ?></div>
+                <div class="card-body">
+                    <form method="post" autocomplete="off">
+                        <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+                        <input type="hidden" name="action" value="create_subscription" />
+                        <div class="mb-3">
+                            <label class="form-label" for="package_id"><?php echo xlt('Package'); ?></label>
+                            <select class="form-select" id="package_id" name="package_id" required>
+                                <option value=""><?php echo xlt('Select'); ?></option>
+                                <?php foreach ($packages as $package) : ?>
+                                    <option value="<?php echo attr($package['package_id']); ?>">
+                                        <?php echo text($package['name']); ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="row">
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="start_date"><?php echo xlt('Start Date'); ?></label>
+                                <input type="text" class="form-control datepicker" id="start_date" name="start_date" />
+                            </div>
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="end_date"><?php echo xlt('End Date'); ?></label>
+                                <input type="text" class="form-control datepicker" id="end_date" name="end_date" />
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="status"><?php echo xlt('Status'); ?></label>
+                            <select class="form-select" id="status" name="status">
+                                <option value="active"><?php echo xlt('Active'); ?></option>
+                                <option value="paused"><?php echo xlt('Paused'); ?></option>
+                                <option value="completed"><?php echo xlt('Completed'); ?></option>
+                                <option value="cancelled"><?php echo xlt('Cancelled'); ?></option>
+                            </select>
+                        </div>
+                        <div class="row">
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="total_sessions"><?php echo xlt('Total Sessions'); ?></label>
+                                <input type="number" min="0" class="form-control" id="total_sessions" name="total_sessions" />
+                            </div>
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="installment_plan"><?php echo xlt('Installment Plan'); ?></label>
+                                <select class="form-select" id="installment_plan" name="installment_plan">
+                                    <option value=""><?php echo xlt('Select'); ?></option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="total_amount"><?php echo xlt('Total Amount'); ?></label>
+                                <input type="number" step="0.01" class="form-control" id="total_amount" name="total_amount" />
+                            </div>
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="promo_price"><?php echo xlt('Promo Applied'); ?></label>
+                                <input type="number" step="0.01" class="form-control" id="promo_price" name="promo_price" />
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="recurring_amount"><?php echo xlt('Recurring Amount'); ?></label>
+                                <input type="number" step="0.01" class="form-control" id="recurring_amount" name="recurring_amount" />
+                            </div>
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="next_billing_date"><?php echo xlt('Next Billing'); ?></label>
+                                <input type="text" class="form-control datepicker" id="next_billing_date" name="next_billing_date" />
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="billing_cycle_count"><?php echo xlt('Billing Every'); ?></label>
+                                <input type="number" min="1" class="form-control" id="billing_cycle_count" name="billing_cycle_count" />
+                            </div>
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="billing_cycle_unit"><?php echo xlt('Cycle Unit'); ?></label>
+                                <select class="form-select" id="billing_cycle_unit" name="billing_cycle_unit">
+                                    <option value=""></option>
+                                    <option value="day"><?php echo xlt('Days'); ?></option>
+                                    <option value="week"><?php echo xlt('Weeks'); ?></option>
+                                    <option value="month"><?php echo xlt('Months'); ?></option>
+                                    <option value="year"><?php echo xlt('Years'); ?></option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="next_session_date"><?php echo xlt('Next Session Target'); ?></label>
+                            <input type="text" class="form-control datepicker" id="next_session_date" name="next_session_date" />
+                        </div>
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" id="auto_bill" name="auto_bill" value="1" />
+                            <label class="form-check-label" for="auto_bill"><?php echo xlt('Enable automatic billing'); ?></label>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="pos_customer_reference"><?php echo xlt('POS Customer Reference'); ?></label>
+                            <input type="text" class="form-control" id="pos_customer_reference" name="pos_customer_reference" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="pos_agreement_reference"><?php echo xlt('POS Agreement'); ?></label>
+                            <input type="text" class="form-control" id="pos_agreement_reference" name="pos_agreement_reference" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="gateway_identifier"><?php echo xlt('Gateway Subscription ID'); ?></label>
+                            <input type="text" class="form-control" id="gateway_identifier" name="gateway_identifier" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="receipt_email"><?php echo xlt('Receipt Email'); ?></label>
+                            <input type="email" class="form-control" id="receipt_email" name="receipt_email" />
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" class="btn btn-primary"><i class="fa fa-save"></i> <?php echo xlt('Create'); ?></button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-header"><?php echo xlt('Log Session'); ?></div>
+                <div class="card-body">
+                    <form method="post">
+                        <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+                        <input type="hidden" name="action" value="log_session" />
+                        <div class="mb-3">
+                            <label class="form-label" for="subscription_id"><?php echo xlt('Subscription'); ?></label>
+                            <select class="form-select" id="subscription_id" name="subscription_id" required>
+                                <option value=""><?php echo xlt('Select'); ?></option>
+                                <?php foreach ($subscriptions as $subscription) : ?>
+                                    <option value="<?php echo attr($subscription['subscription_id']); ?>"><?php echo text($subscription['package_name']); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="session_date"><?php echo xlt('Session Date/Time'); ?></label>
+                            <input type="text" class="form-control datetimepicker" id="session_date" name="session_date" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="session_status"><?php echo xlt('Status'); ?></label>
+                            <select class="form-select" id="session_status" name="session_status">
+                                <option value="completed"><?php echo xlt('Completed'); ?></option>
+                                <option value="scheduled"><?php echo xlt('Scheduled'); ?></option>
+                                <option value="cancelled"><?php echo xlt('Cancelled'); ?></option>
+                                <option value="pending"><?php echo xlt('Pending'); ?></option>
+                            </select>
+                        </div>
+                        <div class="row">
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="provider_id"><?php echo xlt('Provider'); ?></label>
+                                <select class="form-select" id="provider_id" name="provider_id">
+                                    <option value=""><?php echo xlt('Select'); ?></option>
+                                    <?php foreach ($providerRows as $provider) : ?>
+                                        <option value="<?php echo attr($provider['id']); ?>"><?php echo text($provider['lname'] . ', ' . $provider['fname']); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="duration_minutes"><?php echo xlt('Duration (min)'); ?></label>
+                                <input type="number" min="0" class="form-control" id="duration_minutes" name="duration_minutes" />
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="appointment_id"><?php echo xlt('Appointment ID'); ?></label>
+                            <input type="number" class="form-control" id="appointment_id" name="appointment_id" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="notes"><?php echo xlt('Notes'); ?></label>
+                            <textarea class="form-control" id="notes" name="notes" rows="3"></textarea>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" class="btn btn-secondary"><i class="fa fa-check"></i> <?php echo xlt('Log Session'); ?></button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-header"><?php echo xlt('Register Payment'); ?></div>
+                <div class="card-body">
+                    <form method="post">
+                        <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+                        <input type="hidden" name="action" value="record_payment" />
+                        <div class="mb-3">
+                            <label class="form-label" for="payment_subscription_id"><?php echo xlt('Subscription'); ?></label>
+                            <select class="form-select" id="payment_subscription_id" name="payment_subscription_id" required>
+                                <option value=""><?php echo xlt('Select'); ?></option>
+                                <?php foreach ($subscriptions as $subscription) : ?>
+                                    <option value="<?php echo attr($subscription['subscription_id']); ?>"><?php echo text($subscription['package_name']); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="row">
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="payment_amount"><?php echo xlt('Amount'); ?></label>
+                                <input type="number" step="0.01" min="0" class="form-control" id="payment_amount" name="payment_amount" required />
+                            </div>
+                            <div class="col-6 mb-3">
+                                <label class="form-label" for="payment_date"><?php echo xlt('Payment Date'); ?></label>
+                                <input type="text" class="form-control datepicker" id="payment_date" name="payment_date" />
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="payment_reference"><?php echo xlt('Payment Reference'); ?></label>
+                            <input type="text" class="form-control" id="payment_reference" name="payment_reference" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="receipt_reference"><?php echo xlt('Receipt'); ?></label>
+                            <input type="text" class="form-control" id="receipt_reference" name="receipt_reference" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="payment_next_billing"><?php echo xlt('Next Billing Date'); ?></label>
+                            <input type="text" class="form-control datepicker" id="payment_next_billing" name="payment_next_billing" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="payment_notes"><?php echo xlt('Notes'); ?></label>
+                            <textarea class="form-control" id="payment_notes" name="payment_notes" rows="2"></textarea>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" class="btn btn-success"><i class="fa fa-credit-card"></i> <?php echo xlt('Register Payment'); ?></button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-8">
+            <?php if (empty($subscriptions)) : ?>
+                <div class="alert alert-info"><?php echo xlt('No subscriptions for this patient yet.'); ?></div>
+            <?php endif; ?>
+            <?php foreach ($subscriptions as $subscription) :
+                $logs = $service->getSessionLogs((int)$subscription['subscription_id']);
+                $recentLogs = array_slice($logs, 0, 5);
+                ?>
+                <div class="card subscription-card" id="subscription-<?php echo attr($subscription['subscription_id']); ?>">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <div>
+                            <h5 class="mb-0"><?php echo text($subscription['package_name']); ?></h5>
+                            <small class="text-muted"><?php echo xlt('Status'); ?>: <?php echo text(ucfirst($subscription['status'])); ?></small>
+                        </div>
+                        <div>
+                            <?php if (!empty($subscription['next_session_suggestion'])) : ?>
+                                <button type="button" class="btn btn-outline-primary btn-sm" data-next-date="<?php echo attr($subscription['next_session_suggestion']); ?>" onclick="openScheduler(this)">
+                                    <i class="fa fa-calendar-plus"></i> <?php echo xlt('Schedule Next'); ?>
+                                </button>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <dl class="row mb-0">
+                                    <dt class="col-sm-6"><?php echo xlt('Start Date'); ?></dt>
+                                    <dd class="col-sm-6"><?php echo text($subscription['start_date']); ?></dd>
+                                    <dt class="col-sm-6"><?php echo xlt('Next Session'); ?></dt>
+                                    <dd class="col-sm-6"><?php echo text($subscription['next_session_suggestion'] ?? $subscription['next_session_date']); ?></dd>
+                                    <dt class="col-sm-6"><?php echo xlt('Sessions Completed'); ?></dt>
+                                    <dd class="col-sm-6"><?php echo text($subscription['usage']['completed']); ?> / <?php echo text($subscription['total_sessions'] ?? $subscription['session_count'] ?? '-'); ?></dd>
+                                </dl>
+                            </div>
+                            <div class="col-md-6">
+                                <dl class="row mb-0">
+                                    <dt class="col-sm-6"><?php echo xlt('Recurring Amount'); ?></dt>
+                                    <dd class="col-sm-6"><?php echo text(oeFormatMoney($subscription['recurring_amount'] ?? $subscription['total_amount'])); ?></dd>
+                                    <dt class="col-sm-6"><?php echo xlt('Next Billing'); ?></dt>
+                                    <dd class="col-sm-6"><?php echo text($subscription['next_billing_date'] ?: '-'); ?></dd>
+                                    <dt class="col-sm-6"><?php echo xlt('Auto Bill'); ?></dt>
+                                    <dd class="col-sm-6"><?php echo !empty($subscription['auto_bill']) ? xlt('Yes') : xlt('No'); ?></dd>
+                                </dl>
+                            </div>
+                        </div>
+                        <?php if (!empty($recentLogs)) : ?>
+                            <div class="table-responsive mt-3">
+                                <table class="table table-sm session-log-table">
+                                    <thead>
+                                        <tr>
+                                            <th><?php echo xlt('Date'); ?></th>
+                                            <th><?php echo xlt('Type'); ?></th>
+                                            <th><?php echo xlt('Status'); ?></th>
+                                            <th><?php echo xlt('Notes'); ?></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <?php foreach ($recentLogs as $log) : ?>
+                                            <tr>
+                                                <td><?php echo text($log['session_date']); ?></td>
+                                                <td><?php echo text(ucfirst($log['log_type'])); ?></td>
+                                                <td><?php echo text($log['status']); ?></td>
+                                                <td><?php echo text($log['notes'] ?? ''); ?></td>
+                                            </tr>
+                                        <?php endforeach; ?>
+                                    </tbody>
+                                </table>
+                            </div>
+                        <?php else : ?>
+                            <p class="text-muted mt-3"><?php echo xlt('No session history recorded yet.'); ?></p>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+
+    <script>
+        const packageInstallments = <?php echo json_encode($packageInstallments); ?>;
+
+        function updateInstallmentOptions(packageId) {
+            const select = document.getElementById('installment_plan');
+            while (select.firstChild) {
+                select.removeChild(select.firstChild);
+            }
+            const placeholder = document.createElement('option');
+            placeholder.value = '';
+            placeholder.textContent = '<?php echo xlt('Select'); ?>';
+            select.appendChild(placeholder);
+            if (!packageId || !packageInstallments[packageId]) {
+                return;
+            }
+            packageInstallments[packageId].forEach(function (plan) {
+                const option = document.createElement('option');
+                option.value = JSON.stringify(plan);
+                const description = plan.description ? ' - ' + plan.description : '';
+                option.textContent = plan.installments + 'x ' + plan.amount + description;
+                select.appendChild(option);
+            });
+        }
+
+        function openScheduler(button) {
+            const date = button.getAttribute('data-next-date') || '';
+            let url = '../../main/calendar/add_edit_event.php?pid=<?php echo attr_url($pid); ?>';
+            if (date) {
+                url += '&date=' + encodeURIComponent(date);
+            }
+            top.restoreSession();
+            dlgopen(url, '_blank', 900, 600);
+        }
+
+        $(function () {
+            $('.datepicker').datetimepicker({
+                timepicker: false,
+                format: 'Y-m-d'
+            });
+            $('.datetimepicker').datetimepicker({
+                timepicker: true,
+                step: 15,
+                format: 'Y-m-d H:i'
+            });
+
+            $('#package_id').on('change', function () {
+                updateInstallmentOptions(this.value);
+            });
+
+            updateInstallmentOptions($('#package_id').val());
+        });
+    </script>
+</body>
+</html>

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -56,6 +56,7 @@ use OpenEMR\Patient\Cards\DemographicsViewCard;
 use OpenEMR\Patient\Cards\InsuranceViewCard;
 use OpenEMR\Patient\Cards\PortalCard;
 use OpenEMR\Patient\Cards\PatientMediaTimelineCard;
+use OpenEMR\Patient\Cards\PatientPackageSessionsCard;
 use OpenEMR\Reminder\BirthdayReminder;
 use OpenEMR\Services\AllergyIntoleranceService;
 use OpenEMR\Services\ConditionService;
@@ -1515,6 +1516,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                     }
 
                     $patientMediaCard = new PatientMediaTimelineCard((int)$pid);
+                    $packageSessionsCard = new PatientPackageSessionsCard((int)$pid);
 
                     $sectionRenderEvents = $ed->dispatch(new SectionEvent('secondary'), SectionEvent::EVENT_HANDLE);
                     $sectionCards = $sectionRenderEvents->getCards();

--- a/src/Patient/Cards/PatientPackageSessionsCard.php
+++ b/src/Patient/Cards/PatientPackageSessionsCard.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Patient package summary card for Saúde & Estética workflows.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    OpenAI Assistant
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Patient\Cards;
+
+use OpenEMR\Events\Patient\Summary\Card\CardModel;
+use OpenEMR\Events\Patient\Summary\Card\RenderEvent;
+use OpenEMR\Events\Patient\Summary\Card\SectionEvent;
+use OpenEMR\Services\Aesthetic\PackageService;
+
+class PatientPackageSessionsCard extends CardModel
+{
+    private const TEMPLATE_FILE = 'patient/summary/patient_package_sessions_card.html.twig';
+    private const CARD_ID = 'patient_package_sessions';
+
+    private int $pid;
+    private PackageService $packageService;
+
+    public function __construct(int $pid, ?PackageService $packageService = null)
+    {
+        $this->pid = $pid;
+        $this->packageService = $packageService ?? new PackageService();
+        $this->packageService->ensureSchema();
+        parent::__construct($this->buildOptions());
+        $this->attachToSection();
+    }
+
+    private function buildOptions(): array
+    {
+        $summary = $this->packageService->getPatientSummary($this->pid);
+        $detailUrl = $GLOBALS['webroot'] . '/interface/patient_file/saude_estetica/package_sessions.php?pid=' . urlencode($this->pid);
+
+        return [
+            'acl' => ['patients', 'med'],
+            'initiallyCollapsed' => false,
+            'add' => false,
+            'edit' => false,
+            'collapse' => true,
+            'templateFile' => self::TEMPLATE_FILE,
+            'identifier' => self::CARD_ID,
+            'title' => xl('Treatment Packages'),
+            'templateVariables' => [
+                'summary' => $summary,
+                'detailUrl' => $detailUrl,
+            ],
+        ];
+    }
+
+    private function attachToSection(): void
+    {
+        $dispatcher = $this->getEventDispatcher();
+        $dispatcher->addListener(SectionEvent::EVENT_HANDLE, [$this, 'injectCard']);
+    }
+
+    public function injectCard(SectionEvent $event): SectionEvent
+    {
+        if ($event->getSection('secondary')) {
+            $dispatchResult = $this->getEventDispatcher()->dispatch(new RenderEvent(self::CARD_ID), RenderEvent::EVENT_HANDLE);
+            $templateVars = $this->getTemplateVariables();
+            $templateVars['prependedInjection'] = $dispatchResult->getPrependedInjection();
+            $templateVars['appendedInjection'] = $dispatchResult->getAppendedInjection();
+            $this->setTemplateVariables($templateVars);
+            $event->addCard($this);
+        }
+        return $event;
+    }
+}

--- a/src/Services/Aesthetic/PackageService.php
+++ b/src/Services/Aesthetic/PackageService.php
@@ -1,0 +1,861 @@
+<?php
+
+/**
+ * PackageService provides helper methods to create, update and query treatment packages
+ * for the Saúde & Estética workflows. The service owns the database schema lifecycle for
+ * the package catalog, subscription tracking and session/payment logs so that other
+ * presentation layers do not need to worry about schema initialization.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    OpenAI Assistant
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\Aesthetic;
+
+use DateInterval;
+use DateTime;
+use Exception;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Validators\ProcessingResult;
+
+/**
+ * Service facade responsible for all the persistence and orchestration logic that supports
+ * selling treatment packages, tracking recurring payments and keeping a detailed log of the
+ * sessions delivered to a patient.
+ */
+class PackageService
+{
+    private const TABLE_CATALOG = 'package_catalog';
+    private const TABLE_SUBSCRIPTION = 'package_subscription';
+    private const TABLE_SESSION_LOG = 'package_session_log';
+
+    private const PERIODICITY_UNITS = ['day', 'week', 'month', 'year'];
+
+    /**
+     * Ensures that the storage tables exist. This method is idempotent and can safely be called
+     * whenever the service is constructed.
+     */
+    public function ensureSchema(): void
+    {
+        $this->createCatalogTable();
+        $this->createSubscriptionTable();
+        $this->createSessionLogTable();
+    }
+
+    /**
+     * Returns the catalog packages.
+     *
+     * @param bool $activeOnly Whether to limit the results to active packages.
+     * @return array<int, array<string, mixed>>
+     */
+    public function listPackages(bool $activeOnly = false): array
+    {
+        $this->ensureSchema();
+        $sql = 'SELECT pkg.* FROM `' . self::TABLE_CATALOG . '` pkg';
+        $binds = [];
+        if ($activeOnly) {
+            $sql .= ' WHERE pkg.`is_active` = ?';
+            $binds[] = 1;
+        }
+        $sql .= ' ORDER BY pkg.`updated_at` DESC';
+
+        return QueryUtils::fetchRecords($sql, $binds, true);
+    }
+
+    /**
+     * Returns a package row.
+     */
+    public function getPackage(int $packageId): ?array
+    {
+        $this->ensureSchema();
+        $sql = 'SELECT * FROM `' . self::TABLE_CATALOG . '` WHERE `package_id` = ?';
+        $record = QueryUtils::fetchRecords($sql, [$packageId], true);
+        return $record[0] ?? null;
+    }
+
+    /**
+     * Creates or updates a package catalog entry.
+     */
+    public function savePackage(array $payload): ProcessingResult
+    {
+        $this->ensureSchema();
+        $result = new ProcessingResult();
+        $now = date('Y-m-d H:i:s');
+        $name = trim((string)($payload['name'] ?? ''));
+        if ($name === '') {
+            $result->setValidationMessages(['name' => xlt('A package name is required.')]);
+            return $result;
+        }
+
+        $basePrice = $this->parseMoney($payload['base_price'] ?? null);
+        if ($basePrice === null) {
+            $result->setValidationMessages(['base_price' => xlt('A valid base price is required.')]);
+            return $result;
+        }
+
+        $promoPrice = $this->parseMoney($payload['promo_price'] ?? null);
+        $promoStart = $this->parseDate($payload['promo_start_date'] ?? null);
+        $promoEnd = $this->parseDate($payload['promo_end_date'] ?? null);
+        if ($promoPrice !== null && $promoStart === null) {
+            $result->setValidationMessages(['promo_start_date' => xlt('A promotional price requires a start date.')]);
+            return $result;
+        }
+        if ($promoPrice !== null && $promoEnd !== null && $promoStart !== null && $promoEnd < $promoStart) {
+            $result->setValidationMessages(['promo_end_date' => xlt('Promotion end date must be after the start date.')]);
+            return $result;
+        }
+
+        $periodicityUnit = strtolower(trim((string)($payload['periodicity_unit'] ?? 'month')));
+        $periodicityCount = max(1, (int)($payload['periodicity_count'] ?? 1));
+        if (!in_array($periodicityUnit, self::PERIODICITY_UNITS)) {
+            $result->setValidationMessages(['periodicity_unit' => xlt('Invalid periodicity unit.')]);
+            return $result;
+        }
+
+        $sessionCount = null;
+        if (isset($payload['session_count']) && $payload['session_count'] !== '') {
+            $sessionCount = max(0, (int)$payload['session_count']);
+        }
+
+        $installments = $this->normalizeInstallments($payload);
+        if (!$installments['valid']) {
+            $result->setValidationMessages($installments['errors']);
+            return $result;
+        }
+
+        $record = [
+            'package_code' => $this->nullIfEmpty($payload['package_code'] ?? null),
+            'name' => $name,
+            'description' => $this->nullIfEmpty($payload['description'] ?? null),
+            'base_price' => $basePrice,
+            'promo_price' => $promoPrice,
+            'promo_start_date' => $promoStart ? $promoStart->format('Y-m-d') : null,
+            'promo_end_date' => $promoEnd ? $promoEnd->format('Y-m-d') : null,
+            'periodicity_unit' => $periodicityUnit,
+            'periodicity_count' => $periodicityCount,
+            'session_count' => $sessionCount,
+            'installment_options' => !empty($installments['data']) ? json_encode($installments['data']) : null,
+            'is_active' => !empty($payload['is_active']) ? 1 : 0,
+            'metadata' => $this->encodeMetadata($payload['metadata'] ?? []),
+            'updated_at' => $now,
+        ];
+
+        $packageId = isset($payload['package_id']) ? (int)$payload['package_id'] : 0;
+        if ($packageId > 0) {
+            $set = [];
+            $binds = [];
+            foreach ($record as $column => $value) {
+                $set[] = "`$column` = ?";
+                $binds[] = $value;
+            }
+            $binds[] = $packageId;
+            QueryUtils::sqlStatementThrowException(
+                'UPDATE `' . self::TABLE_CATALOG . '` SET ' . implode(', ', $set) . ' WHERE `package_id` = ?',
+                $binds,
+                true
+            );
+            $result->addData(array_merge(['package_id' => $packageId], $record));
+        } else {
+            $createdAt = $now;
+            $values = [
+                $record['package_code'],
+                $record['name'],
+                $record['description'],
+                $record['base_price'],
+                $record['promo_price'],
+                $record['promo_start_date'],
+                $record['promo_end_date'],
+                $record['periodicity_unit'],
+                $record['periodicity_count'],
+                $record['session_count'],
+                $record['installment_options'],
+                $record['is_active'],
+                $record['metadata'],
+                $createdAt,
+                $record['updated_at'],
+            ];
+            $newId = QueryUtils::sqlInsert(
+                'INSERT INTO `' . self::TABLE_CATALOG . '` (`package_code`, `name`, `description`, `base_price`, `promo_price`, '
+                . '`promo_start_date`, `promo_end_date`, `periodicity_unit`, `periodicity_count`, `session_count`, `installment_options`, '
+                . '`is_active`, `metadata`, `created_at`, `updated_at`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                $values
+            );
+            $result->addData(array_merge(['package_id' => $newId], $record, ['created_at' => $createdAt]));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Deletes a package from the catalog.
+     */
+    public function deletePackage(int $packageId): void
+    {
+        $this->ensureSchema();
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `' . self::TABLE_CATALOG . '` WHERE `package_id` = ?',
+            [$packageId],
+            true
+        );
+    }
+
+    /**
+     * Creates a patient subscription to a catalog package.
+     */
+    public function createSubscription(array $payload): ProcessingResult
+    {
+        $this->ensureSchema();
+        $result = new ProcessingResult();
+        $now = date('Y-m-d H:i:s');
+
+        $patientId = (int)($payload['patient_id'] ?? 0);
+        $packageId = (int)($payload['package_id'] ?? 0);
+        if ($patientId <= 0 || $packageId <= 0) {
+            $result->setValidationMessages(['subscription' => xlt('A patient and a package are required.')]);
+            return $result;
+        }
+
+        $package = $this->getPackage($packageId);
+        if (empty($package)) {
+            $result->setValidationMessages(['package_id' => xlt('Package not found.')]);
+            return $result;
+        }
+
+        $startDate = $this->parseDate($payload['start_date'] ?? null) ?? new DateTime();
+        $status = in_array(($payload['status'] ?? 'active'), ['active', 'paused', 'completed', 'cancelled'])
+            ? $payload['status']
+            : 'active';
+
+        $installmentSelection = $payload['installment_plan'] ?? null;
+        if (is_array($installmentSelection)) {
+            $installmentSelection = json_encode($installmentSelection);
+        }
+
+        $totalSessions = $payload['total_sessions'] ?? $package['session_count'] ?? null;
+        $totalSessions = $totalSessions !== null ? max(0, (int)$totalSessions) : null;
+
+        $autoBill = !empty($payload['auto_bill']) ? 1 : 0;
+        $billingUnit = $payload['billing_cycle_unit'] ?? $package['periodicity_unit'];
+        $billingCount = $payload['billing_cycle_count'] ?? $package['periodicity_count'];
+        if ($billingUnit && !in_array($billingUnit, self::PERIODICITY_UNITS)) {
+            $billingUnit = $package['periodicity_unit'];
+        }
+        $billingCount = $billingCount ? max(1, (int)$billingCount) : $package['periodicity_count'];
+
+        $nextSessionDate = $this->formatDate($payload['next_session_date'] ?? null);
+        if ($nextSessionDate === null) {
+            $nextSessionDate = $startDate->format('Y-m-d');
+        }
+
+        $record = [
+            'package_id' => $packageId,
+            'patient_id' => $patientId,
+            'start_date' => $startDate->format('Y-m-d'),
+            'end_date' => $this->formatDate($payload['end_date'] ?? null),
+            'status' => $status,
+            'total_sessions' => $totalSessions,
+            'installment_selection' => $this->nullIfEmpty($installmentSelection),
+            'total_amount' => $this->parseMoney($payload['total_amount'] ?? $package['base_price']),
+            'promo_price' => $this->parseMoney($payload['promo_price'] ?? $package['promo_price']),
+            'recurring_amount' => $this->parseMoney($payload['recurring_amount'] ?? null),
+            'next_session_date' => $nextSessionDate,
+            'next_billing_date' => $this->formatDate($payload['next_billing_date'] ?? null),
+            'billing_cycle_unit' => $billingUnit,
+            'billing_cycle_count' => $billingCount,
+            'auto_bill' => $autoBill,
+            'pos_customer_reference' => $this->nullIfEmpty($payload['pos_customer_reference'] ?? null),
+            'pos_agreement_reference' => $this->nullIfEmpty($payload['pos_agreement_reference'] ?? null),
+            'gateway_identifier' => $this->nullIfEmpty($payload['gateway_identifier'] ?? null),
+            'receipt_email' => $this->nullIfEmpty($payload['receipt_email'] ?? null),
+            'metadata' => $this->encodeMetadata($payload['metadata'] ?? []),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+
+        $insertId = QueryUtils::sqlInsert(
+            'INSERT INTO `' . self::TABLE_SUBSCRIPTION . '` (`package_id`, `patient_id`, `start_date`, `end_date`, `status`, '
+            . '`total_sessions`, `installment_selection`, `total_amount`, `promo_price`, `recurring_amount`, `next_session_date`, '
+            . '`next_billing_date`, `billing_cycle_unit`, `billing_cycle_count`, `auto_bill`, `pos_customer_reference`, '
+            . '`pos_agreement_reference`, `gateway_identifier`, `receipt_email`, `metadata`, `created_at`, `updated_at`)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            array_values($record)
+        );
+
+        $result->addData(array_merge(['subscription_id' => $insertId], $record));
+        return $result;
+    }
+
+    /**
+     * Updates subscription metadata such as the next billing date or status.
+     */
+    public function updateSubscription(int $subscriptionId, array $payload): void
+    {
+        $this->ensureSchema();
+        $fields = [];
+        $binds = [];
+        $allowed = [
+            'status', 'end_date', 'next_session_date', 'next_billing_date', 'billing_cycle_unit', 'billing_cycle_count',
+            'auto_bill', 'recurring_amount', 'pos_customer_reference', 'pos_agreement_reference', 'gateway_identifier',
+            'receipt_email', 'metadata'
+        ];
+
+        foreach ($allowed as $column) {
+            if (!array_key_exists($column, $payload)) {
+                continue;
+            }
+
+            $value = $payload[$column];
+            switch ($column) {
+                case 'end_date':
+                case 'next_session_date':
+                case 'next_billing_date':
+                    $value = $this->formatDate($value);
+                    break;
+                case 'billing_cycle_unit':
+                    if ($value && !in_array($value, self::PERIODICITY_UNITS)) {
+                        continue 2;
+                    }
+                    break;
+                case 'billing_cycle_count':
+                    $value = $value !== null ? max(1, (int)$value) : null;
+                    break;
+                case 'auto_bill':
+                    $value = !empty($value) ? 1 : 0;
+                    break;
+                case 'metadata':
+                    $value = $this->encodeMetadata($value ?? []);
+                    break;
+                default:
+                    $value = $this->nullIfEmpty($value);
+            }
+
+            $fields[] = "`$column` = ?";
+            $binds[] = $value;
+        }
+
+        if (empty($fields)) {
+            return;
+        }
+
+        $fields[] = '`updated_at` = ?';
+        $binds[] = date('Y-m-d H:i:s');
+        $binds[] = $subscriptionId;
+
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE `' . self::TABLE_SUBSCRIPTION . '` SET ' . implode(', ', $fields) . ' WHERE `subscription_id` = ?',
+            $binds,
+            true
+        );
+    }
+
+    /**
+     * Returns a list of subscriptions for a patient with aggregated usage counters.
+     */
+    public function getSubscriptionsForPatient(int $patientId): array
+    {
+        $this->ensureSchema();
+        $sql = 'SELECT sub.*, pkg.`name` AS package_name, pkg.`periodicity_unit`, pkg.`periodicity_count`, pkg.`session_count`, '
+            . 'pkg.`installment_options`, pkg.`base_price` AS package_base_price, pkg.`promo_price` AS package_promo_price'
+            . ' FROM `' . self::TABLE_SUBSCRIPTION . '` sub'
+            . ' INNER JOIN `' . self::TABLE_CATALOG . '` pkg ON pkg.`package_id` = sub.`package_id`'
+            . ' WHERE sub.`patient_id` = ?'
+            . ' ORDER BY sub.`created_at` DESC';
+        $rows = QueryUtils::fetchRecords($sql, [$patientId], true);
+        foreach ($rows as &$row) {
+            $row['installment_options_decoded'] = $this->decodeJson($row['installment_selection']);
+            $row['package_installments'] = $this->decodeJson($row['installment_options']);
+            $row['usage'] = $this->getSubscriptionUsage((int)$row['subscription_id']);
+            $row['next_session_suggestion'] = $this->getNextSuggestedSessionDate($row);
+        }
+        unset($row);
+        return $rows;
+    }
+
+    /**
+     * Returns the aggregated session log entries for a subscription.
+     */
+    public function getSessionLogs(int $subscriptionId): array
+    {
+        $this->ensureSchema();
+        $sql = 'SELECT log.* FROM `' . self::TABLE_SESSION_LOG . '` log'
+            . ' WHERE log.`subscription_id` = ?'
+            . ' ORDER BY log.`session_date` DESC, log.`created_at` DESC';
+        return QueryUtils::fetchRecords($sql, [$subscriptionId], true);
+    }
+
+    /**
+     * Stores a session or payment event for a subscription.
+     */
+    public function logSubscriptionEvent(array $payload): ProcessingResult
+    {
+        $this->ensureSchema();
+        $result = new ProcessingResult();
+        $subscriptionId = (int)($payload['subscription_id'] ?? 0);
+        if ($subscriptionId <= 0) {
+            $result->setValidationMessages(['subscription_id' => xlt('A subscription is required.')]);
+            return $result;
+        }
+
+        $logType = $payload['log_type'] ?? 'session';
+        if (!in_array($logType, ['session', 'payment', 'note'], true)) {
+            $result->setValidationMessages(['log_type' => xlt('Unsupported log entry type.')]);
+            return $result;
+        }
+
+        $now = date('Y-m-d H:i:s');
+        $sessionDate = $this->parseDateTime($payload['session_date'] ?? null);
+        $status = $payload['status'] ?? ($logType === 'session' ? 'completed' : 'recorded');
+        $duration = $payload['duration_minutes'] ?? null;
+        $duration = $duration !== null && $duration !== '' ? max(0, (int)$duration) : null;
+        $paymentAmount = $this->parseMoney($payload['payment_amount'] ?? null);
+
+        $record = [
+            'subscription_id' => $subscriptionId,
+            'log_type' => $logType,
+            'session_date' => $sessionDate ? $sessionDate->format('Y-m-d H:i:s') : null,
+            'status' => $status,
+            'provider_id' => $payload['provider_id'] !== '' ? (int)$payload['provider_id'] : null,
+            'appointment_id' => $payload['appointment_id'] !== '' ? (int)$payload['appointment_id'] : null,
+            'notes' => $this->nullIfEmpty($payload['notes'] ?? null),
+            'duration_minutes' => $duration,
+            'payment_amount' => $paymentAmount,
+            'payment_reference' => $this->nullIfEmpty($payload['payment_reference'] ?? null),
+            'receipt_reference' => $this->nullIfEmpty($payload['receipt_reference'] ?? null),
+            'metadata' => $this->encodeMetadata($payload['metadata'] ?? []),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+
+        $insertId = QueryUtils::sqlInsert(
+            'INSERT INTO `' . self::TABLE_SESSION_LOG . '` (`subscription_id`, `log_type`, `session_date`, `status`, `provider_id`, '
+            . '`appointment_id`, `notes`, `duration_minutes`, `payment_amount`, `payment_reference`, `receipt_reference`, `metadata`, '
+            . '`created_at`, `updated_at`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            array_values($record)
+        );
+
+        $result->addData(array_merge(['log_id' => $insertId], $record));
+        return $result;
+    }
+
+    /**
+     * Returns a short high level summary of a patient subscriptions.
+     */
+    public function getPatientSummary(int $patientId): array
+    {
+        $subscriptions = $this->getSubscriptionsForPatient($patientId);
+        $active = array_filter($subscriptions, static function ($row) {
+            return ($row['status'] ?? '') === 'active';
+        });
+        $upcoming = null;
+        foreach ($subscriptions as $subscription) {
+            $suggested = $subscription['next_session_suggestion'];
+            if ($suggested === null) {
+                continue;
+            }
+            if ($upcoming === null || $suggested < $upcoming['date']) {
+                $upcoming = [
+                    'date' => $suggested,
+                    'package_name' => $subscription['package_name'],
+                ];
+            }
+        }
+
+        $paymentsDue = null;
+        foreach ($subscriptions as $subscription) {
+            $nextBilling = $subscription['next_billing_date'];
+            if (!$nextBilling) {
+                continue;
+            }
+            if ($paymentsDue === null || $nextBilling < $paymentsDue['date']) {
+                $paymentsDue = [
+                    'date' => $nextBilling,
+                    'amount' => $subscription['recurring_amount'] ?: $subscription['total_amount'],
+                    'package_name' => $subscription['package_name'],
+                ];
+            }
+        }
+
+        $recentSessions = $this->getRecentSessions($patientId);
+
+        return [
+            'active_count' => count($active),
+            'total_subscriptions' => count($subscriptions),
+            'upcoming_session' => $upcoming,
+            'next_billing' => $paymentsDue,
+            'recent_sessions' => $recentSessions,
+        ];
+    }
+
+    /**
+     * Convenience helper that records a POS payment in the session log and moves the billing cycle forward.
+     */
+    public function registerRecurringPayment(int $subscriptionId, float $amount, ?string $paidAt = null, array $metadata = []): void
+    {
+        $this->logSubscriptionEvent([
+            'subscription_id' => $subscriptionId,
+            'log_type' => 'payment',
+            'session_date' => $paidAt ?? date('Y-m-d H:i:s'),
+            'status' => 'paid',
+            'payment_amount' => $amount,
+            'payment_reference' => $metadata['payment_reference'] ?? null,
+            'receipt_reference' => $metadata['receipt_reference'] ?? null,
+            'notes' => $metadata['notes'] ?? null,
+            'metadata' => $metadata,
+        ]);
+
+        if (!empty($metadata['next_billing_date'])) {
+            $this->updateSubscription($subscriptionId, ['next_billing_date' => $metadata['next_billing_date']]);
+        }
+    }
+
+    /**
+     * Calculates how many sessions were consumed, scheduled and completed.
+     */
+    public function getSubscriptionUsage(int $subscriptionId): array
+    {
+        $this->ensureSchema();
+        $sql = 'SELECT log.`log_type`, log.`status` FROM `' . self::TABLE_SESSION_LOG . '` log WHERE log.`subscription_id` = ?';
+        $records = QueryUtils::fetchRecords($sql, [$subscriptionId], true);
+        $usage = [
+            'completed' => 0,
+            'scheduled' => 0,
+            'payments' => 0,
+        ];
+        foreach ($records as $record) {
+            if ($record['log_type'] === 'session') {
+                if ($record['status'] === 'completed') {
+                    $usage['completed']++;
+                } elseif ($record['status'] === 'scheduled') {
+                    $usage['scheduled']++;
+                }
+            } elseif ($record['log_type'] === 'payment') {
+                $usage['payments']++;
+            }
+        }
+        return $usage;
+    }
+
+    /**
+     * Determines the next recommended session datetime for a subscription.
+     */
+    public function getNextSuggestedSessionDate(array $subscription): ?string
+    {
+        $lastSession = $this->getLastSessionDate((int)$subscription['subscription_id']);
+        $reference = $lastSession ?? $subscription['next_session_date'] ?? $subscription['start_date'];
+        if (!$reference) {
+            return null;
+        }
+
+        try {
+            $date = new DateTime($reference);
+        } catch (Exception $e) {
+            return null;
+        }
+
+        $unit = $subscription['periodicity_unit'] ?? 'month';
+        $count = $subscription['periodicity_count'] ?? 1;
+        $intervalSpec = $this->buildIntervalSpec($unit, (int)$count);
+        if ($intervalSpec === null) {
+            return $date->format('Y-m-d');
+        }
+
+        $date->add(new DateInterval($intervalSpec));
+        return $date->format('Y-m-d');
+    }
+
+    /**
+     * Returns the list of installment plans stored in the catalog row.
+     */
+    public function getInstallmentOptions(array $package): array
+    {
+        $options = $this->decodeJson($package['installment_options'] ?? null);
+        if (empty($options) || !is_array($options)) {
+            return [];
+        }
+        return $options;
+    }
+
+    /**
+     * Extracts recent session history for the patient to display in summary cards.
+     */
+    private function getRecentSessions(int $patientId): array
+    {
+        $sql = 'SELECT log.`log_id`, log.`session_date`, log.`status`, log.`notes`, pkg.`name` AS package_name'
+            . ' FROM `' . self::TABLE_SESSION_LOG . '` log'
+            . ' INNER JOIN `' . self::TABLE_SUBSCRIPTION . '` sub ON sub.`subscription_id` = log.`subscription_id`'
+            . ' INNER JOIN `' . self::TABLE_CATALOG . '` pkg ON pkg.`package_id` = sub.`package_id`'
+            . ' WHERE sub.`patient_id` = ? AND log.`log_type` = ?'
+            . ' ORDER BY log.`session_date` DESC, log.`created_at` DESC'
+            . ' LIMIT 5';
+        return QueryUtils::fetchRecords($sql, [$patientId, 'session'], true);
+    }
+
+    private function getLastSessionDate(int $subscriptionId): ?string
+    {
+        $sql = 'SELECT log.`session_date` FROM `' . self::TABLE_SESSION_LOG . '` log'
+            . ' WHERE log.`subscription_id` = ? AND log.`log_type` = ? AND log.`status` = ?'
+            . ' ORDER BY log.`session_date` DESC, log.`log_id` DESC LIMIT 1';
+        $value = QueryUtils::fetchSingleValue($sql, 'session_date', [$subscriptionId, 'session', 'completed']);
+        return $value ?: null;
+    }
+
+    private function parseMoney($value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $normalized = preg_replace('/[^0-9.,-]/', '', (string)$value);
+        if ($normalized === '') {
+            return null;
+        }
+        $normalized = str_replace(',', '.', $normalized);
+        if (substr_count($normalized, '.') > 1) {
+            $parts = explode('.', $normalized);
+            $decimal = array_pop($parts);
+            $normalized = implode('', $parts) . '.' . $decimal;
+        }
+        return (float)$normalized;
+    }
+
+    private function parseDate($value): ?DateTime
+    {
+        if (!$value) {
+            return null;
+        }
+        try {
+            return new DateTime((string)$value);
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+
+    private function parseDateTime($value): ?DateTime
+    {
+        if (!$value) {
+            return null;
+        }
+        try {
+            return new DateTime((string)$value);
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+
+    private function formatDate($value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $date = $this->parseDate($value);
+        return $date ? $date->format('Y-m-d') : null;
+    }
+
+    private function nullIfEmpty($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+        $value = is_string($value) ? trim($value) : $value;
+        if ($value === '' || $value === []) {
+            return null;
+        }
+        return $value;
+    }
+
+    private function normalizeInstallments(array $payload): array
+    {
+        $options = $payload['installments'] ?? [];
+        if (empty($options) && isset($payload['installment_counts'])) {
+            $options = [];
+            $counts = $payload['installment_counts'];
+            $amounts = $payload['installment_amounts'] ?? [];
+            $descriptions = $payload['installment_descriptions'] ?? [];
+            foreach ((array)$counts as $index => $count) {
+                $count = (int)$count;
+                $amount = $amounts[$index] ?? null;
+                if ($count <= 0 || $amount === null || $amount === '') {
+                    continue;
+                }
+                $options[] = [
+                    'installments' => $count,
+                    'amount' => $amount,
+                    'description' => trim((string)($descriptions[$index] ?? '')),
+                ];
+            }
+        }
+
+        $errors = [];
+        $normalized = [];
+        foreach ((array)$options as $option) {
+            $count = (int)($option['installments'] ?? 0);
+            if ($count <= 0) {
+                $errors['installments'] = xlt('Installment count must be greater than zero.');
+                continue;
+            }
+            $amount = $this->parseMoney($option['amount'] ?? null);
+            if ($amount === null || $amount <= 0) {
+                $errors['installments'] = xlt('Installment amount must be a positive value.');
+                continue;
+            }
+            $normalized[] = [
+                'installments' => $count,
+                'amount' => $amount,
+                'description' => $this->nullIfEmpty($option['description'] ?? null),
+            ];
+        }
+
+        return [
+            'valid' => empty($errors),
+            'errors' => $errors,
+            'data' => $normalized,
+        ];
+    }
+
+    private function encodeMetadata($metadata): ?string
+    {
+        if (empty($metadata)) {
+            return null;
+        }
+        if (!is_array($metadata)) {
+            return json_encode(['value' => $metadata]);
+        }
+        return json_encode($metadata);
+    }
+
+    private function decodeJson($value)
+    {
+        if (!$value) {
+            return [];
+        }
+        $decoded = json_decode((string)$value, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function buildIntervalSpec(string $unit, int $count): ?string
+    {
+        $count = max(1, $count);
+        switch ($unit) {
+            case 'day':
+                return 'P' . $count . 'D';
+            case 'week':
+                return 'P' . $count . 'W';
+            case 'month':
+                return 'P' . $count . 'M';
+            case 'year':
+                return 'P' . $count . 'Y';
+            default:
+                return null;
+        }
+    }
+
+    private function createCatalogTable(): void
+    {
+        if (QueryUtils::existsTable(self::TABLE_CATALOG)) {
+            return;
+        }
+        $sql = sprintf(
+            'CREATE TABLE `%s` ('
+            . ' `package_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,'
+            . ' `package_code` VARCHAR(50) DEFAULT NULL,'
+            . ' `name` VARCHAR(120) NOT NULL,'
+            . ' `description` TEXT DEFAULT NULL,'
+            . ' `base_price` DECIMAL(12,2) NOT NULL DEFAULT 0.00,'
+            . ' `promo_price` DECIMAL(12,2) DEFAULT NULL,'
+            . ' `promo_start_date` DATE DEFAULT NULL,'
+            . ' `promo_end_date` DATE DEFAULT NULL,'
+            . ' `periodicity_unit` ENUM("day","week","month","year") NOT NULL DEFAULT "month",'
+            . ' `periodicity_count` TINYINT UNSIGNED NOT NULL DEFAULT 1,'
+            . ' `session_count` SMALLINT UNSIGNED DEFAULT NULL,'
+            . ' `installment_options` LONGTEXT DEFAULT NULL,'
+            . ' `is_active` TINYINT(1) NOT NULL DEFAULT 1,'
+            . ' `metadata` LONGTEXT DEFAULT NULL,'
+            . ' `created_at` DATETIME NOT NULL,'
+            . ' `updated_at` DATETIME NOT NULL,'
+            . ' PRIMARY KEY (`package_id`),'
+            . ' UNIQUE KEY `uniq_package_code` (`package_code`),'
+            . ' KEY `idx_package_active` (`is_active`)'
+            . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci',
+            self::TABLE_CATALOG
+        );
+        \sqlStatementNoLog($sql);
+    }
+
+    private function createSubscriptionTable(): void
+    {
+        if (QueryUtils::existsTable(self::TABLE_SUBSCRIPTION)) {
+            return;
+        }
+        $sql = sprintf(
+            'CREATE TABLE `%s` ('
+            . ' `subscription_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,'
+            . ' `package_id` INT UNSIGNED NOT NULL,'
+            . ' `patient_id` BIGINT UNSIGNED NOT NULL,'
+            . ' `start_date` DATE NOT NULL,'
+            . ' `end_date` DATE DEFAULT NULL,'
+            . ' `status` ENUM("active","paused","completed","cancelled") NOT NULL DEFAULT "active",'
+            . ' `total_sessions` SMALLINT UNSIGNED DEFAULT NULL,'
+            . ' `installment_selection` LONGTEXT DEFAULT NULL,'
+            . ' `total_amount` DECIMAL(12,2) DEFAULT NULL,'
+            . ' `promo_price` DECIMAL(12,2) DEFAULT NULL,'
+            . ' `recurring_amount` DECIMAL(12,2) DEFAULT NULL,'
+            . ' `next_session_date` DATE DEFAULT NULL,'
+            . ' `next_billing_date` DATE DEFAULT NULL,'
+            . ' `billing_cycle_unit` ENUM("day","week","month","year") DEFAULT NULL,'
+            . ' `billing_cycle_count` TINYINT UNSIGNED DEFAULT NULL,'
+            . ' `auto_bill` TINYINT(1) NOT NULL DEFAULT 0,'
+            . ' `pos_customer_reference` VARCHAR(191) DEFAULT NULL,'
+            . ' `pos_agreement_reference` VARCHAR(191) DEFAULT NULL,'
+            . ' `gateway_identifier` VARCHAR(191) DEFAULT NULL,'
+            . ' `receipt_email` VARCHAR(191) DEFAULT NULL,'
+            . ' `metadata` LONGTEXT DEFAULT NULL,'
+            . ' `created_at` DATETIME NOT NULL,'
+            . ' `updated_at` DATETIME NOT NULL,'
+            . ' PRIMARY KEY (`subscription_id`),'
+            . ' KEY `idx_subscription_patient` (`patient_id`),'
+            . ' KEY `idx_subscription_status` (`status`),'
+            . ' CONSTRAINT `fk_subscription_package` FOREIGN KEY (`package_id`) REFERENCES `%s` (`package_id`)'
+            . '   ON DELETE CASCADE ON UPDATE CASCADE'
+            . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci',
+            self::TABLE_SUBSCRIPTION,
+            self::TABLE_CATALOG
+        );
+        \sqlStatementNoLog($sql);
+    }
+
+    private function createSessionLogTable(): void
+    {
+        if (QueryUtils::existsTable(self::TABLE_SESSION_LOG)) {
+            return;
+        }
+        $sql = sprintf(
+            'CREATE TABLE `%s` ('
+            . ' `log_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,'
+            . ' `subscription_id` INT UNSIGNED NOT NULL,'
+            . ' `log_type` ENUM("session","payment","note") NOT NULL DEFAULT "session",'
+            . ' `session_date` DATETIME DEFAULT NULL,'
+            . ' `status` VARCHAR(40) DEFAULT NULL,'
+            . ' `provider_id` INT DEFAULT NULL,'
+            . ' `appointment_id` INT DEFAULT NULL,'
+            . ' `notes` TEXT DEFAULT NULL,'
+            . ' `duration_minutes` SMALLINT UNSIGNED DEFAULT NULL,'
+            . ' `payment_amount` DECIMAL(12,2) DEFAULT NULL,'
+            . ' `payment_reference` VARCHAR(191) DEFAULT NULL,'
+            . ' `receipt_reference` VARCHAR(191) DEFAULT NULL,'
+            . ' `metadata` LONGTEXT DEFAULT NULL,'
+            . ' `created_at` DATETIME NOT NULL,'
+            . ' `updated_at` DATETIME NOT NULL,'
+            . ' PRIMARY KEY (`log_id`),'
+            . ' KEY `idx_session_subscription` (`subscription_id`),'
+            . ' KEY `idx_session_type` (`log_type`),'
+            . ' KEY `idx_session_date` (`session_date`),'
+            . ' CONSTRAINT `fk_session_subscription` FOREIGN KEY (`subscription_id`) REFERENCES `%s` (`subscription_id`)'
+            . '   ON DELETE CASCADE ON UPDATE CASCADE'
+            . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci',
+            self::TABLE_SESSION_LOG,
+            self::TABLE_SUBSCRIPTION
+        );
+        \sqlStatementNoLog($sql);
+    }
+}

--- a/templates/patient/summary/patient_package_sessions_card.html.twig
+++ b/templates/patient/summary/patient_package_sessions_card.html.twig
@@ -1,0 +1,43 @@
+{% extends "patient/card/card_base.html.twig" %}
+{% if (prependedInjection is defined) or (appendedInjection is defined) %}
+    {% import "patient/macros/card.macro.twig" as cardMacros %}
+    {% set prepend = cardMacros.injectedContent(prependedInjection) %}
+    {% set append = cardMacros.injectedContent(appendedInjection) %}
+{% endif %}
+{% block content %}
+    <div class="px-1">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <div class="d-flex w-100 text-center">
+                <div class="flex-fill">
+                    <div class="h5 mb-0">{{ summary.active_count|default(0) }}</div>
+                    <small class="text-muted">{{ 'Active Packages'|xlt }}</small>
+                </div>
+                <div class="flex-fill">
+                    <div class="h5 mb-0">{{ summary.upcoming_session.date|default('-') }}</div>
+                    <small class="text-muted">{{ 'Next Session'|xlt }}</small>
+                </div>
+                <div class="flex-fill">
+                    <div class="h5 mb-0">{{ summary.next_billing.amount is defined ? summary.next_billing.amount|oeFormatMoney : '-' }}</div>
+                    <small class="text-muted">{{ 'Next Billing'|xlt }}</small>
+                </div>
+            </div>
+            <a class="btn btn-sm btn-outline-primary ms-2" href="{{ detailUrl|attr }}" target="_blank">
+                <i class="fa fa-external-link"></i> {{ 'Manage'|xlt }}
+            </a>
+        </div>
+        <hr class="my-2" />
+        {% if summary.recent_sessions is not empty %}
+            <ul class="list-unstyled mb-0">
+                {% for session in summary.recent_sessions %}
+                    <li class="mb-1">
+                        <strong>{{ session.package_name }}</strong>
+                        <div class="small text-muted">{{ session.session_date }}</div>
+                        {% if session.notes %}<div class="small">{{ session.notes }}</div>{% endif %}
+                    </li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p class="text-muted mb-0">{{ 'No recent sessions recorded.'|xlt }}</p>
+        {% endif %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated `PackageService` that installs the package catalog, subscription, and session log tables and exposes helpers for recurring billing workflows
- create an admin screen to configure Saúde & Estética packages with pricing, periodicity, and installment plans and wire it into the admin menu
- add patient-facing tracking tools, including a new summary card and full page for managing subscriptions, logging sessions, and initiating follow-up scheduling

## Testing
- php -l interface/billing/saude_estetica/packages.php
- php -l interface/patient_file/saude_estetica/package_sessions.php
- php -l src/Patient/Cards/PatientPackageSessionsCard.php
- php -l src/Services/Aesthetic/PackageService.php

------
https://chatgpt.com/codex/tasks/task_e_68d9c8366aec8331a4afa4d6092b8779