### PR TITLE
feat: expand checkout for multi-payment workflows

### DIFF
--- a/public/checkout_webhook.php
+++ b/public/checkout_webhook.php
@@ -1,0 +1,23 @@
+<?php
+
+use OpenEMR\Services\Checkout\PaymentGatewayManager;
+
+require_once __DIR__ . '/../interface/globals.php';
+
+$gateway = strtolower($_GET['gateway'] ?? '');
+$rawPayload = file_get_contents('php://input');
+$data = json_decode($rawPayload ?: '[]', true);
+if (!is_array($data)) {
+    $data = array();
+}
+
+$manager = new PaymentGatewayManager();
+if (!$manager->supports($gateway)) {
+    http_response_code(400);
+    echo json_encode(array('status' => 'error', 'message' => 'Unsupported gateway.'));
+    return;
+}
+
+$response = $manager->handleWebhook($gateway, $data);
+header('Content-Type: application/json');
+echo json_encode(array('status' => 'ok', 'data' => $response));

--- a/src/Services/Checkout/CheckoutService.php
+++ b/src/Services/Checkout/CheckoutService.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace OpenEMR\Services\Checkout;
+
+use OpenEMR\Services\Checkout\Exception\PaymentProcessingException;
+use Psr\Log\LoggerInterface;
+
+class CheckoutService
+{
+    public function __construct(
+        private PaymentGatewayManager $gatewayManager,
+        private PaymentLedgerService $ledgerService,
+        private ?LoggerInterface $logger = null
+    ) {
+    }
+
+    public function processPayments(
+        int $patientId,
+        int $encounterId,
+        array $payments,
+        string $serviceDate,
+        string $postTimestamp,
+        array $context
+    ): array {
+        $results = array();
+        foreach ($payments as $payment) {
+            $amount = isset($payment['amount']) ? (float)$payment['amount'] : 0.0;
+            if ($amount <= 0) {
+                continue;
+            }
+            $method = $payment['method'] ?? 'cash';
+            $gateway = $payment['gateway'] ?? null;
+            $reference = $payment['reference'] ?? '';
+            $installments = isset($payment['installments']) ? (int)$payment['installments'] : 1;
+            $sessionId = $this->createSession(
+                $patientId,
+                $serviceDate,
+                $amount,
+                $reference,
+                $method
+            );
+            $this->createActivity(
+                $sessionId,
+                $patientId,
+                $encounterId,
+                $amount,
+                $context['code_type'] ?? '',
+                $context['code'] ?? '',
+                $context['modifier'] ?? ''
+            );
+            $metadata = array(
+                'reference' => $reference,
+                'installments' => $installments,
+                'gateway' => $gateway,
+                'session_id' => $sessionId,
+                'method' => $method
+            );
+            if (!empty($gateway)) {
+                try {
+                    $gatewayResponse = $this->gatewayManager->dispatchPayment($gateway, array(
+                        'session_id' => $sessionId,
+                        'patient_id' => $patientId,
+                        'encounter_id' => $encounterId,
+                        'amount' => $amount,
+                        'reference' => $reference,
+                        'installments' => $installments
+                    ));
+                    $metadata['gateway_response'] = $gatewayResponse;
+                } catch (\Exception $exception) {
+                    if ($this->logger) {
+                        $this->logger->error('Gateway dispatch failed', ['exception' => $exception]);
+                    }
+                    throw new PaymentProcessingException($exception->getMessage(), 0, $exception);
+                }
+            }
+            $this->ledgerService->recordPayment(
+                $sessionId,
+                $patientId,
+                $encounterId,
+                $method,
+                $gateway,
+                $installments,
+                $amount,
+                $metadata,
+                $postTimestamp
+            );
+            $results[] = array(
+                'session_id' => $sessionId,
+                'amount' => $amount,
+                'method' => $method
+            );
+        }
+        if (empty($results)) {
+            throw new PaymentProcessingException('No valid payments were provided for processing.');
+        }
+        return $results;
+    }
+
+    private function createSession(
+        int $patientId,
+        string $serviceDate,
+        float $amount,
+        string $reference,
+        string $method
+    ): int {
+        $sql = "INSERT INTO ar_session (payer_id,user_id,reference,check_date,deposit_date,pay_total,global_amount,payment_type,description,patient_id,payment_method,adjustment_code,post_to_date) "
+            . " VALUES ('0',?,?,now(),?,?,'','patient','COPAY',?,?,'patient_payment',now())";
+        return \sqlInsert($sql, array(
+            $_SESSION['authUserID'],
+            $reference,
+            $serviceDate,
+            $amount,
+            $patientId,
+            $method
+        ));
+    }
+
+    private function createActivity(
+        int $sessionId,
+        int $patientId,
+        int $encounterId,
+        float $amount,
+        string $codeType,
+        string $code,
+        string $modifier
+    ): void {
+        \sqlBeginTrans();
+        $sequence = \sqlQuery(
+            "SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = ? AND encounter = ?",
+            array($patientId, $encounterId)
+        );
+        $sql = "INSERT INTO ar_activity (pid,encounter,sequence_no,code_type,code,modifier,payer_type,post_time,post_user,session_id,pay_amount,account_code)"
+            . " VALUES (?,?,?,?,?,?,0,?,?,?,?,'PCP')";
+        \sqlInsert(
+            $sql,
+            array(
+                $patientId,
+                $encounterId,
+                $sequence['increment'],
+                $codeType,
+                $code,
+                $modifier,
+                date('Y-m-d H:i:s'),
+                $_SESSION['authUserID'],
+                $sessionId,
+                $amount
+            )
+        );
+        \sqlCommitTrans();
+    }
+}
+

--- a/src/Services/Checkout/Exception/PaymentProcessingException.php
+++ b/src/Services/Checkout/Exception/PaymentProcessingException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace OpenEMR\Services\Checkout\Exception;
+
+use RuntimeException;
+
+class PaymentProcessingException extends RuntimeException
+{
+}
+

--- a/src/Services/Checkout/Gateway/AbstractGatewayService.php
+++ b/src/Services/Checkout/Gateway/AbstractGatewayService.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace OpenEMR\Services\Checkout\Gateway;
+
+abstract class AbstractGatewayService
+{
+    private static bool $schemaInitialized = false;
+
+    public function __construct(protected ?\Psr\Log\LoggerInterface $logger = null)
+    {
+        $this->ensureSchema();
+    }
+
+    abstract public function dispatch(array $payload): array;
+
+    abstract public function handleWebhook(array $payload): array;
+
+    protected function ensureSchema(): void
+    {
+        if (self::$schemaInitialized) {
+            return;
+        }
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS payment_gateway_transactions (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    session_id BIGINT UNSIGNED NULL,
+    gateway VARCHAR(64) NOT NULL,
+    external_id VARCHAR(128) DEFAULT NULL,
+    status VARCHAR(32) DEFAULT 'pending',
+    payload TEXT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_gateway (gateway),
+    KEY idx_external (external_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        \sqlStatement($sql);
+        self::$schemaInitialized = true;
+    }
+
+    protected function persistTransaction(string $gateway, ?int $sessionId, string $externalId, string $status, array $payload): void
+    {
+        $now = date('Y-m-d H:i:s');
+        $existing = \sqlQuery(
+            "SELECT id FROM payment_gateway_transactions WHERE gateway = ? AND external_id = ? LIMIT 1",
+            array($gateway, $externalId)
+        );
+        if (!empty($existing['id'])) {
+            \sqlStatement(
+                "UPDATE payment_gateway_transactions SET status = ?, payload = ?, updated_at = ? WHERE id = ?",
+                array($status, json_encode($payload), $now, $existing['id'])
+            );
+        } else {
+            \sqlStatement(
+                "INSERT INTO payment_gateway_transactions (session_id, gateway, external_id, status, payload, created_at, updated_at) VALUES (?,?,?,?,?,?,?)",
+                array($sessionId, $gateway, $externalId, $status, json_encode($payload), $now, $now)
+            );
+        }
+    }
+}
+

--- a/src/Services/Checkout/Gateway/PagSeguroGatewayService.php
+++ b/src/Services/Checkout/Gateway/PagSeguroGatewayService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OpenEMR\Services\Checkout\Gateway;
+
+class PagSeguroGatewayService extends AbstractGatewayService
+{
+    public function dispatch(array $payload): array
+    {
+        $externalId = $payload['external_id'] ?? ('pagseguro_' . bin2hex(random_bytes(8)));
+        $sessionId = $payload['session_id'] ?? null;
+        $record = array(
+            'session_id' => $sessionId,
+            'amount' => $payload['amount'] ?? 0,
+            'reference' => $payload['reference'] ?? '',
+            'installments' => $payload['installments'] ?? 1,
+            'metadata' => $payload
+        );
+        $this->persistTransaction('pagseguro', $sessionId, $externalId, 'pending', $record);
+        return array(
+            'status' => 'pending',
+            'external_id' => $externalId
+        );
+    }
+
+    public function handleWebhook(array $payload): array
+    {
+        $externalId = $payload['code'] ?? $payload['external_id'] ?? '';
+        if ($externalId === '') {
+            return array('status' => 'ignored');
+        }
+        $status = $payload['status'] ?? 'completed';
+        $sessionId = $payload['session_id'] ?? null;
+        $this->persistTransaction('pagseguro', $sessionId, $externalId, $status, $payload);
+        return array('status' => $status);
+    }
+}
+

--- a/src/Services/Checkout/Gateway/StripeGatewayService.php
+++ b/src/Services/Checkout/Gateway/StripeGatewayService.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace OpenEMR\Services\Checkout\Gateway;
+
+class StripeGatewayService extends AbstractGatewayService
+{
+    public function dispatch(array $payload): array
+    {
+        $externalId = $payload['external_id'] ?? ('stripe_' . bin2hex(random_bytes(8)));
+        $sessionId = $payload['session_id'] ?? null;
+        $amount = $payload['amount'] ?? 0;
+        $record = array(
+            'session_id' => $sessionId,
+            'amount' => $amount,
+            'reference' => $payload['reference'] ?? '',
+            'installments' => $payload['installments'] ?? 1,
+            'metadata' => $payload
+        );
+        $this->persistTransaction('stripe', $sessionId, $externalId, 'pending', $record);
+        return array(
+            'status' => 'pending',
+            'external_id' => $externalId
+        );
+    }
+
+    public function handleWebhook(array $payload): array
+    {
+        $externalId = $payload['id'] ?? $payload['external_id'] ?? '';
+        if ($externalId === '') {
+            return array('status' => 'ignored');
+        }
+        $status = $payload['status'] ?? 'completed';
+        $sessionId = $payload['session_id'] ?? null;
+        $this->persistTransaction('stripe', $sessionId, $externalId, $status, $payload);
+        return array('status' => $status);
+    }
+}
+

--- a/src/Services/Checkout/PaymentGatewayManager.php
+++ b/src/Services/Checkout/PaymentGatewayManager.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OpenEMR\Services\Checkout;
+
+use OpenEMR\Services\Checkout\Exception\PaymentProcessingException;
+use OpenEMR\Services\Checkout\Gateway\AbstractGatewayService;
+use OpenEMR\Services\Checkout\Gateway\PagSeguroGatewayService;
+use OpenEMR\Services\Checkout\Gateway\StripeGatewayService;
+use Psr\Log\LoggerInterface;
+
+class PaymentGatewayManager
+{
+    /** @var array<string, AbstractGatewayService> */
+    private array $gateways;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->gateways = array(
+            'stripe' => new StripeGatewayService($logger),
+            'pagseguro' => new PagSeguroGatewayService($logger)
+        );
+    }
+
+    public function dispatchPayment(string $gatewayKey, array $payload): array
+    {
+        $gateway = $this->getGateway($gatewayKey);
+        return $gateway->dispatch($payload);
+    }
+
+    public function handleWebhook(string $gatewayKey, array $payload): array
+    {
+        $gateway = $this->getGateway($gatewayKey);
+        return $gateway->handleWebhook($payload);
+    }
+
+    public function supports(string $gatewayKey): bool
+    {
+        $normalized = strtolower($gatewayKey);
+        return isset($this->gateways[$normalized]);
+    }
+
+    private function getGateway(string $gatewayKey): AbstractGatewayService
+    {
+        $normalized = strtolower($gatewayKey);
+        if (!$this->supports($normalized)) {
+            throw new PaymentProcessingException(sprintf('Unsupported gateway "%s"', $gatewayKey));
+        }
+        return $this->gateways[$normalized];
+    }
+}
+

--- a/src/Services/Checkout/PaymentLedgerService.php
+++ b/src/Services/Checkout/PaymentLedgerService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace OpenEMR\Services\Checkout;
+
+use DateTimeImmutable;
+use OpenEMR\Common\Logging\SystemLogger;
+
+class PaymentLedgerService
+{
+    private static bool $schemaInitialized = false;
+
+    public function __construct(private ?SystemLogger $logger = null)
+    {
+        $this->initializeSchema();
+    }
+
+    public function recordPayment(
+        ?int $sessionId,
+        int $patientId,
+        int $encounterId,
+        string $method,
+        ?string $gateway,
+        int $installments,
+        float $amount,
+        array $metadata,
+        string $timestamp
+    ): void {
+        $this->initializeSchema();
+        $createdAt = new DateTimeImmutable($timestamp);
+        $meta = json_encode($metadata);
+        $sql = "INSERT INTO ar_payment_ledger (session_id, patient_id, encounter_id, payment_method, gateway, installments, amount, created_at, metadata) "
+            . "VALUES (?,?,?,?,?,?,?,?,?)";
+        try {
+            \sqlStatement($sql, array(
+                $sessionId,
+                $patientId,
+                $encounterId,
+                $method,
+                $gateway,
+                max(1, $installments),
+                $amount,
+                $createdAt->format('Y-m-d H:i:s'),
+                $meta
+            ));
+        } catch (\Exception $exception) {
+            if ($this->logger) {
+                $this->logger->error('Failed to record payment ledger entry', ['exception' => $exception]);
+            }
+            throw $exception;
+        }
+    }
+
+    private function initializeSchema(): void
+    {
+        if (self::$schemaInitialized) {
+            return;
+        }
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS ar_payment_ledger (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    session_id BIGINT UNSIGNED NULL,
+    patient_id BIGINT UNSIGNED NOT NULL,
+    encounter_id BIGINT UNSIGNED NOT NULL,
+    payment_method VARCHAR(64) NOT NULL,
+    gateway VARCHAR(64) DEFAULT NULL,
+    installments INT UNSIGNED DEFAULT 1,
+    amount DECIMAL(12,2) NOT NULL,
+    created_at DATETIME NOT NULL,
+    metadata TEXT NULL,
+    PRIMARY KEY (id),
+    KEY idx_patient (patient_id),
+    KEY idx_encounter (encounter_id),
+    KEY idx_session (session_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        \sqlStatement($sql);
+        self::$schemaInitialized = true;
+    }
+}
+


### PR DESCRIPTION
## Summary
- refactor the checkout UI/controller to support multi-method payments, kit quick-picks, and zero-encounter sales
- add checkout services for ledger recording, gateway abstraction, and webhook handling
- expose a webhook endpoint for gateway callbacks and persist gateway transaction metadata

## Testing
- php -l interface/patient_file/pos_checkout_normal.php
- php -l public/checkout_webhook.php
- php -l src/Services/Checkout/CheckoutService.php
- php -l src/Services/Checkout/PaymentLedgerService.php
- php -l src/Services/Checkout/PaymentGatewayManager.php
- php -l src/Services/Checkout/Gateway/AbstractGatewayService.php
- php -l src/Services/Checkout/Gateway/StripeGatewayService.php
- php -l src/Services/Checkout/Gateway/PagSeguroGatewayService.php
- php -l src/Services/Checkout/Exception/PaymentProcessingException.php

------
https://chatgpt.com/codex/tasks/task_e_68d9d1fe12bc8331a863bccceb24ebee